### PR TITLE
Add conversation flow system

### DIFF
--- a/migrations/20250726100000-create-flows.js
+++ b/migrations/20250726100000-create-flows.js
@@ -1,0 +1,52 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('flows', {
+      id: { allowNull: false, autoIncrement: true, primaryKey: true, type: Sequelize.INTEGER },
+      cliente_id: { type: Sequelize.INTEGER, allowNull: false },
+      nome: { type: Sequelize.STRING, allowNull: false },
+      gatilho: { type: Sequelize.STRING, allowNull: false },
+      ativo: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 1 },
+      createdAt: { allowNull: false, type: Sequelize.DATE, defaultValue: Sequelize.fn('NOW') },
+      updatedAt: { allowNull: false, type: Sequelize.DATE, defaultValue: Sequelize.fn('NOW') }
+    });
+
+    await queryInterface.createTable('flow_nodes', {
+      id: { allowNull: false, autoIncrement: true, primaryKey: true, type: Sequelize.INTEGER },
+      flow_id: { type: Sequelize.INTEGER, allowNull: false, references: { model: 'flows', key: 'id' }, onDelete: 'CASCADE' },
+      tipo: { type: Sequelize.STRING, allowNull: false },
+      conteudo: { type: Sequelize.TEXT, allowNull: true },
+      next_node_id: { type: Sequelize.INTEGER, allowNull: true },
+      createdAt: { allowNull: false, type: Sequelize.DATE, defaultValue: Sequelize.fn('NOW') },
+      updatedAt: { allowNull: false, type: Sequelize.DATE, defaultValue: Sequelize.fn('NOW') }
+    });
+
+    await queryInterface.createTable('node_options', {
+      id: { allowNull: false, autoIncrement: true, primaryKey: true, type: Sequelize.INTEGER },
+      node_id: { type: Sequelize.INTEGER, allowNull: false, references: { model: 'flow_nodes', key: 'id' }, onDelete: 'CASCADE' },
+      label: { type: Sequelize.STRING, allowNull: false },
+      next_node_id: { type: Sequelize.INTEGER, allowNull: true },
+      createdAt: { allowNull: false, type: Sequelize.DATE, defaultValue: Sequelize.fn('NOW') },
+      updatedAt: { allowNull: false, type: Sequelize.DATE, defaultValue: Sequelize.fn('NOW') }
+    });
+
+    await queryInterface.createTable('user_flow_state', {
+      id: { allowNull: false, autoIncrement: true, primaryKey: true, type: Sequelize.INTEGER },
+      cliente_id: { type: Sequelize.INTEGER, allowNull: false },
+      telefone: { type: Sequelize.STRING, allowNull: false },
+      flow_id: { type: Sequelize.INTEGER, allowNull: false, references: { model: 'flows', key: 'id' }, onDelete: 'CASCADE' },
+      node_id: { type: Sequelize.INTEGER, allowNull: true, references: { model: 'flow_nodes', key: 'id' }, onDelete: 'SET NULL' },
+      updatedAt: { allowNull: false, type: Sequelize.DATE, defaultValue: Sequelize.fn('NOW') },
+      createdAt: { allowNull: false, type: Sequelize.DATE, defaultValue: Sequelize.fn('NOW') }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('user_flow_state');
+    await queryInterface.dropTable('node_options');
+    await queryInterface.dropTable('flow_nodes');
+    await queryInterface.dropTable('flows');
+  }
+};

--- a/public/index.html
+++ b/public/index.html
@@ -16,6 +16,7 @@
                 <li><button class="nav-btn active" data-view="chat-view" title="Conversas"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg></button></li>
                 <li><button class="nav-btn" data-view="contacts-view" title="Contatos"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/></svg></button></li>
                 <li><button class="nav-btn" data-view="automations-view" title="Automações"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 16.5 3.5 10l.9-8.6L13 1l8.6.9L18 10l-4 1 3 3-3 3-4-1zM2 22l4-4"></path><path d="m14.2 11.2 4.6-4.6"></path></svg></button></li>
+                <li><button class="nav-btn" data-view="flows-view" title="Fluxos"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 5 15.4a1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09A1.65 1.65 0 0 0 15 4.6a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09A1.65 1.65 0 0 0 19.4 15z"></path></svg></button></li>
                 <li><button class="nav-btn" data-view="integrations-view" title="Integrações"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.72"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.72-1.72"></path></svg></button></li>
                 <li><button class="nav-btn" data-view="reports-view" title="Relatórios"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"></path><path d="M18.7 8a6 6 0 0 0-6-6H3.3"></path><path d="M7 12h5"></path><path d="M7 16h9"></path></svg></button></li>
                 <li><button class="nav-btn" data-view="tracking-view" title="Rastreios"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7"></path><path d="M16 3h5v5"></path><path d="M22 3 16 9"></path></svg></button></li>
@@ -295,6 +296,19 @@
         </div>
     </div>
 </div>
+            <div id="flows-view" class="view-container hidden">
+                <div class="page-container">
+                    <header class="page-header">
+                        <div>
+                            <h1>Fluxos de Conversa</h1>
+                            <p>Crie sequências interativas de mensagens.</p>
+                        </div>
+                    </header>
+                    <div id="flows-list" class="settings-card">
+                        <p>Aqui serão listados os fluxos cadastrados.</p>
+                    </div>
+                </div>
+            </div>
             <div id="integrations-view" class="view-container hidden">
                 <div class="page-container">
                     <header class="page-header">

--- a/public/script.js
+++ b/public/script.js
@@ -375,7 +375,8 @@ const btnEnvioCancelarEl = document.getElementById('btn-envio-cancelar');
         });
 
         if (viewId === 'contacts-view') loadContacts();
-        if (viewId === 'automations-view') loadAutomations();
+       if (viewId === 'automations-view') loadAutomations();
+        if (viewId === 'flows-view') loadFlows();
         if (viewId === 'integrations-view') {
             showIntegrationsList();
             loadIntegrationInfo();
@@ -1363,6 +1364,25 @@ const btnEnvioCancelarEl = document.getElementById('btn-envio-cancelar');
         } catch (err) {
             plansListEl.innerHTML = '<p class="info-mensagem" style="color: red;">Erro ao carregar os planos. Tente novamente mais tarde.</p>';
             console.error(err);
+        }
+    }
+
+    async function loadFlows() {
+        const listEl = document.getElementById('flows-list');
+        if (!listEl) return;
+        listEl.innerHTML = '<p class="info-mensagem">A carregar...</p>';
+        try {
+            const resp = await authFetch('/api/flows');
+            if (!resp.ok) throw new Error('Falha ao carregar fluxos.');
+            const flows = await resp.json();
+            listEl.innerHTML = '';
+            flows.forEach(f => {
+                const div = document.createElement('div');
+                div.textContent = `${f.nome} (gatilho: ${f.gatilho})`;
+                listEl.appendChild(div);
+            });
+        } catch (err) {
+            listEl.innerHTML = '<p class="info-mensagem" style="color:red">Erro ao carregar fluxos.</p>';
         }
     }
 

--- a/src/app.js
+++ b/src/app.js
@@ -7,6 +7,7 @@ const pedidosController = require('./controllers/pedidosController');
 const envioController = require('./controllers/envioController');
 const rastreamentoController = require('./controllers/rastreamentoController');
 const automationsController = require('./controllers/automationsController');
+const flowsController = require('./controllers/flowsController');
 const integrationsController = require('./controllers/integrationsController');
 const logsController = require('./controllers/logsController');
 const paymentController = require('./controllers/paymentController');
@@ -163,6 +164,11 @@ function createExpressApp(db, sessionManager) {
   app.get('/api/automations', planCheck, automationsController.listarAutomacoes);
   app.post('/api/automations', planCheck, automationsController.salvarAutomacoes);
   app.post('/api/automations/test', planCheck, automationsController.testarAutomacao);
+  app.get('/api/flows', planCheck, flowsController.listarFlows);
+  app.post('/api/flows', planCheck, flowsController.criarFlow);
+  app.get('/api/flows/:id', planCheck, flowsController.getFlow);
+  app.put('/api/flows/:id', planCheck, flowsController.atualizarFlow);
+  app.delete('/api/flows/:id', planCheck, flowsController.deletarFlow);
 
   app.get('/api/reports/summary', planCheck, reportsController.getReportSummary);
   app.get('/api/reports/tracking', planCheck, reportsController.getTrackingReport);

--- a/src/controllers/flowsController.js
+++ b/src/controllers/flowsController.js
@@ -1,0 +1,50 @@
+const flowService = require('../services/flowService');
+
+exports.listarFlows = async (req, res) => {
+  try {
+    const flows = await flowService.listFlows(req.user.id);
+    res.json(flows);
+  } catch (err) {
+    res.status(500).json({ error: 'Falha ao listar fluxos' });
+  }
+};
+
+exports.criarFlow = async (req, res) => {
+  try {
+    const flow = await flowService.saveFlow(req.user.id, req.body);
+    res.status(201).json(flow);
+  } catch (err) {
+    res.status(500).json({ error: 'Falha ao criar fluxo' });
+  }
+};
+
+exports.getFlow = async (req, res) => {
+  const id = parseInt(req.params.id);
+  try {
+    const flow = await flowService.getFlowById(id, req.user.id);
+    if (!flow) return res.status(404).json({ error: 'Fluxo não encontrado' });
+    res.json(flow);
+  } catch (err) {
+    res.status(500).json({ error: 'Falha ao obter fluxo' });
+  }
+};
+
+exports.atualizarFlow = async (req, res) => {
+  const id = parseInt(req.params.id);
+  try {
+    const flow = await flowService.updateFlow(id, req.user.id, req.body);
+    res.json(flow);
+  } catch (err) {
+    res.status(500).json({ error: 'Falha ao atualizar fluxo' });
+  }
+};
+
+exports.deletarFlow = async (req, res) => {
+  const id = parseInt(req.params.id);
+  try {
+    await flowService.deleteFlow(id, req.user.id);
+    res.status(204).end();
+  } catch (err) {
+    res.status(500).json({ error: 'Falha ao deletar fluxo' });
+  }
+};

--- a/src/database/database.js
+++ b/src/database/database.js
@@ -154,6 +154,37 @@ function defineModels(sequelize) {
     mediaUrl: DataTypes.STRING
   }, { tableName: 'automacao_passos', timestamps: true });
 
+  const Flow = sequelize.define('Flow', {
+    id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    cliente_id: { type: DataTypes.INTEGER, allowNull: false },
+    nome: { type: DataTypes.STRING, allowNull: false },
+    gatilho: { type: DataTypes.STRING, allowNull: false },
+    ativo: { type: DataTypes.INTEGER, defaultValue: 1 }
+  }, { tableName: 'flows', timestamps: true });
+
+  const FlowNode = sequelize.define('FlowNode', {
+    id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    flow_id: { type: DataTypes.INTEGER, allowNull: false },
+    tipo: { type: DataTypes.STRING, allowNull: false },
+    conteudo: DataTypes.TEXT,
+    next_node_id: DataTypes.INTEGER
+  }, { tableName: 'flow_nodes', timestamps: true });
+
+  const NodeOption = sequelize.define('NodeOption', {
+    id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    node_id: { type: DataTypes.INTEGER, allowNull: false },
+    label: { type: DataTypes.STRING, allowNull: false },
+    next_node_id: DataTypes.INTEGER
+  }, { tableName: 'node_options', timestamps: true });
+
+  const UserFlowState = sequelize.define('UserFlowState', {
+    id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    cliente_id: { type: DataTypes.INTEGER, allowNull: false },
+    telefone: { type: DataTypes.STRING, allowNull: false },
+    flow_id: { type: DataTypes.INTEGER, allowNull: false },
+    node_id: DataTypes.INTEGER
+  }, { tableName: 'user_flow_state', timestamps: true });
+
   const Integration = sequelize.define('Integration', {
     id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
     user_id: { type: DataTypes.INTEGER, allowNull: false },
@@ -188,7 +219,12 @@ function defineModels(sequelize) {
   Automacao.hasMany(AutomacaoPasso, { foreignKey: 'gatilho', sourceKey: 'gatilho' });
   AutomacaoPasso.belongsTo(Automacao, { foreignKey: 'gatilho', targetKey: 'gatilho' });
 
-  return { User, Plan, Subscription, Pedido, Historico, Log, Automacao, AutomacaoPasso, Integration, IntegrationSetting, UserSetting };
+  Flow.hasMany(FlowNode, { foreignKey: 'flow_id' });
+  FlowNode.belongsTo(Flow, { foreignKey: 'flow_id' });
+  FlowNode.hasMany(NodeOption, { foreignKey: 'node_id' });
+  NodeOption.belongsTo(FlowNode, { foreignKey: 'node_id' });
+
+  return { User, Plan, Subscription, Pedido, Historico, Log, Automacao, AutomacaoPasso, Integration, IntegrationSetting, UserSetting, Flow, FlowNode, NodeOption, UserFlowState };
 }
 
 let sequelize;

--- a/src/services/flowEngineService.js
+++ b/src/services/flowEngineService.js
@@ -1,0 +1,55 @@
+const { getModels } = require('../database/database');
+const whatsappService = require('./whatsappService');
+
+async function sendNode(client, telefone, node) {
+  if (!node) return;
+  if (node.tipo === 'mensagem' || node.tipo === 'message') {
+    await whatsappService.enviarMensagem(client, telefone, node.conteudo || '');
+  } else if (node.tipo === 'pergunta' || node.tipo === 'question') {
+    const { NodeOption } = getModels();
+    const opts = await NodeOption.findAll({ where: { node_id: node.id } });
+    const texto = [node.conteudo || '', ...opts.map(o => `- ${o.label}`)].join('\n');
+    await whatsappService.enviarMensagem(client, telefone, texto);
+  }
+}
+
+async function processMessage(clienteId, telefone, text, client) {
+  const { Flow, FlowNode, NodeOption, UserFlowState } = getModels();
+  let state = await UserFlowState.findOne({ where: { cliente_id: clienteId, telefone } });
+
+  if (state) {
+    const current = await FlowNode.findByPk(state.node_id);
+    if (!current) { await state.destroy(); return; }
+
+    if (current.tipo === 'pergunta' || current.tipo === 'question') {
+      const option = await NodeOption.findOne({ where: { node_id: current.id, label: text } });
+      if (!option) return; // opção inválida
+      const nextId = option.next_node_id;
+      if (nextId) {
+        const next = await FlowNode.findByPk(nextId);
+        await sendNode(client, telefone, next);
+        await state.update({ node_id: nextId });
+      } else {
+        await state.destroy();
+      }
+    } else {
+      if (current.next_node_id) {
+        const next = await FlowNode.findByPk(current.next_node_id);
+        await sendNode(client, telefone, next);
+        await state.update({ node_id: current.next_node_id });
+      } else {
+        await state.destroy();
+      }
+    }
+    return;
+  }
+
+  const flow = await Flow.findOne({ where: { cliente_id: clienteId, gatilho: text, ativo: 1 } });
+  if (!flow) return;
+  const first = await FlowNode.findOne({ where: { flow_id: flow.id }, order: [['id', 'ASC']] });
+  if (!first) return;
+  await sendNode(client, telefone, first);
+  await UserFlowState.create({ cliente_id: clienteId, telefone, flow_id: flow.id, node_id: first.id });
+}
+
+module.exports = { processMessage };

--- a/src/services/flowService.js
+++ b/src/services/flowService.js
@@ -1,0 +1,106 @@
+const { getModels, getSequelize } = require('../database/database');
+
+async function listFlows(clienteId) {
+  const { Flow, FlowNode, NodeOption } = getModels();
+  return Flow.findAll({
+    where: { cliente_id: clienteId },
+    include: { model: FlowNode, include: NodeOption }
+  });
+}
+
+async function getFlowById(id, clienteId) {
+  const { Flow, FlowNode, NodeOption } = getModels();
+  return Flow.findOne({
+    where: { id, cliente_id: clienteId },
+    include: { model: FlowNode, include: NodeOption }
+  });
+}
+
+async function saveFlow(clienteId, flowData) {
+  const { Flow, FlowNode, NodeOption } = getModels();
+  const sequelize = getSequelize();
+  const tx = await sequelize.transaction();
+  try {
+    const flow = await Flow.create({
+      cliente_id: clienteId,
+      nome: flowData.nome,
+      gatilho: flowData.gatilho,
+      ativo: flowData.ativo !== undefined ? flowData.ativo : 1
+    }, { transaction: tx });
+
+    if (Array.isArray(flowData.nodes)) {
+      for (const n of flowData.nodes) {
+        const node = await FlowNode.create({
+          flow_id: flow.id,
+          tipo: n.tipo,
+          conteudo: n.conteudo || null,
+          next_node_id: n.next_node_id || null
+        }, { transaction: tx });
+
+        if (Array.isArray(n.options)) {
+          for (const opt of n.options) {
+            await NodeOption.create({
+              node_id: node.id,
+              label: opt.label,
+              next_node_id: opt.next_node_id || null
+            }, { transaction: tx });
+          }
+        }
+      }
+    }
+
+    await tx.commit();
+    return flow;
+  } catch (err) {
+    await tx.rollback();
+    throw err;
+  }
+}
+
+async function updateFlow(id, clienteId, flowData) {
+  const { Flow, FlowNode, NodeOption } = getModels();
+  const sequelize = getSequelize();
+  const tx = await sequelize.transaction();
+  try {
+    await Flow.update({
+      nome: flowData.nome,
+      gatilho: flowData.gatilho,
+      ativo: flowData.ativo
+    }, { where: { id, cliente_id: clienteId }, transaction: tx });
+
+    await FlowNode.destroy({ where: { flow_id: id }, transaction: tx });
+
+    if (Array.isArray(flowData.nodes)) {
+      for (const n of flowData.nodes) {
+        const node = await FlowNode.create({
+          flow_id: id,
+          tipo: n.tipo,
+          conteudo: n.conteudo || null,
+          next_node_id: n.next_node_id || null
+        }, { transaction: tx });
+        if (Array.isArray(n.options)) {
+          for (const opt of n.options) {
+            await NodeOption.create({
+              node_id: node.id,
+              label: opt.label,
+              next_node_id: opt.next_node_id || null
+            }, { transaction: tx });
+          }
+        }
+      }
+    }
+
+    await tx.commit();
+    return getFlowById(id, clienteId);
+  } catch (err) {
+    await tx.rollback();
+    throw err;
+  }
+}
+
+async function deleteFlow(id, clienteId) {
+  const { Flow } = getModels();
+  return Flow.destroy({ where: { id, cliente_id: clienteId } });
+}
+
+module.exports = { listFlows, saveFlow, updateFlow, deleteFlow, getFlowById };

--- a/src/whatsappSessions.js
+++ b/src/whatsappSessions.js
@@ -4,6 +4,7 @@ const path = require('path');
 const whatsappService = require('./services/whatsappService');
 const pedidoService = require('./services/pedidoService');
 const settingsService = require('./services/settingsService');
+const flowEngine = require('./services/flowEngineService');
 const { processIncomingMessage } = require('./utils/messageUtils');
 
 function createWhatsAppManager(app, { broadcastStatus, broadcastToUser }) {
@@ -56,6 +57,7 @@ function createWhatsAppManager(app, { broadcastStatus, broadcastToUser }) {
           messageType
         );
         broadcastToUser(userId, { type: 'nova_mensagem', pedidoId: pedido.id });
+        await flowEngine.processMessage(clienteId, telefoneCliente, messageContent, client);
       } catch (error) {
         console.error('[onMessage] Erro ao processar mensagem:', error);
       }


### PR DESCRIPTION
## Summary
- create new database models for conversation flows
- expose REST endpoints to manage flows
- implement flow service and engine
- integrate flow engine with WhatsApp message handling
- add minimal UI for conversation flows
- add migration for database tables

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6883b74eab0c8321b84721895c648de8