### PR TITLE
Fix module path for WhatsApp service

### DIFF
--- a/src/flows/flowEngineService.js
+++ b/src/flows/flowEngineService.js
@@ -1,5 +1,6 @@
 const { getModels } = require('../database/database');
-const whatsappService = require('./whatsappService');
+// Corrige caminho do serviço de WhatsApp
+const whatsappService = require('../services/whatsappService');
 
 async function sendNode(client, telefone, node) {
   if (!node) return;


### PR DESCRIPTION
## Summary
- correct the path to the WhatsApp service in `flowEngineService`

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6883cea195c08321bd60bd7cfcde1e7b