### PR TITLE
Add initial flows UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -297,15 +297,17 @@
     </div>
 </div>
             <div id="flows-view" class="view-container hidden">
-                <div id="flows-list-view" class="page-container">
+                <div class="page-container" id="flows-list-view">
                     <header class="page-header">
                         <div>
                             <h1>Fluxos de Conversa</h1>
-                            <p>Crie sequências interativas de mensagens.</p>
+                            <p>Crie e gira os seus chatbots interativos.</p>
                         </div>
-                        <button class="btn-primary" id="btn-new-flow">Criar Novo Fluxo</button>
+                        <button class="btn-primary" id="btn-create-new-flow">Criar Novo Fluxo</button>
                     </header>
-                    <div id="flows-list" class="flows-list"></div>
+                    <div id="flows-list-container" class="card-table">
+                        <div id="flows-list" class="flows-list"></div>
+                    </div>
                 </div>
 
                 <div id="flow-editor-view" class="page-container hidden">

--- a/public/script.js
+++ b/public/script.js
@@ -376,7 +376,7 @@ const btnEnvioCancelarEl = document.getElementById('btn-envio-cancelar');
 
         if (viewId === 'contacts-view') loadContacts();
        if (viewId === 'automations-view') loadAutomations();
-        if (viewId === 'flows-view') loadFlows();
+        if (viewId === 'flows-view') loadAndRenderFlows();
         if (viewId === 'integrations-view') {
             showIntegrationsList();
             loadIntegrationInfo();
@@ -1410,6 +1410,42 @@ const btnEnvioCancelarEl = document.getElementById('btn-envio-cancelar');
         }
     }
 
+    async function loadAndRenderFlows() {
+        if (!flowsListContainer) return;
+        flowsListContainer.innerHTML = '<p class="info-mensagem">A carregar...</p>';
+        try {
+            const resp = await authFetch('/api/flows');
+            if (!resp.ok) throw new Error('Falha ao carregar fluxos.');
+            flowsCache = await resp.json();
+            flowsListContainer.innerHTML = '';
+            if (!flowsCache.length) {
+                flowsListContainer.innerHTML = '<p class="info-mensagem">Nenhum fluxo cadastrado.</p>';
+                return;
+            }
+            flowsCache.forEach(f => {
+                const card = document.createElement('div');
+                card.className = 'flow-card';
+                card.dataset.flowId = f.id;
+                card.innerHTML = `
+                    <div class="flow-info">
+                        <h4>${escapeHtml(f.nome)}</h4>
+                        <p>Gatilho: ${escapeHtml(f.gatilho)}</p>
+                    </div>
+                    <div class="flow-actions">
+                        <button class="btn-icon btn-edit-flow" title="Editar">
+                            <svg width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M9.405 1.05c-.413-1.4-2.397-1.4-2.81 0l-.1.34a1.464 1.464 0 0 1-2.105.872l-.31-.17c-1.283-.698-2.686.705-1.987 1.987l.169.311a1.464 1.464 0 0 1-.872 2.105l-.34.1c-1.4.413-1.4 2.397 0 2.81l.34.1a1.464 1.464 0 0 1 .872 2.105l-.17.31c-.698 1.283.705 2.686 1.987 1.987l.311-.169a1.464 1.464 0 0 1 2.105.872l.1.34c.413 1.4 2.397 1.4 2.81 0l.1-.34a1.464 1.464 0 0 1 2.105-.872l.31.17c1.283.698 2.686-.705 1.987-1.987l-.169-.311a1.464 1.464 0 0 1 .872-2.105l.34-.1c1.4-.413-1.4-2.397 0-2.81l-.34-.1a1.464 1.464 0 0 1-.872-2.105l.17-.31c.698-1.283-.705-2.686-1.987-1.987l-.311.169a1.464 1.464 0 0 1-2.105-.872zM8 10.93a2.929 2.929 0 1 1 0-5.86 2.929 2.929 0 0 1 0 5.858z"/></svg>
+                        </button>
+                        <button class="btn-icon btn-delete-flow" title="Excluir">
+                            <svg width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0z"/><path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4zM2.5 3h11V2h-11z"/></svg>
+                        </button>
+                    </div>`;
+                flowsListContainer.appendChild(card);
+            });
+        } catch (err) {
+            flowsListContainer.innerHTML = '<p class="info-mensagem" style="color:red">Erro ao carregar fluxos.</p>';
+        }
+    }
+
     function renderContactsPagination(total) {
         if (!contactsPaginationEl) return;
         const totalPages = Math.max(1, Math.ceil(total / contactsLimit));
@@ -2018,13 +2054,14 @@ const btnEnvioCancelarEl = document.getElementById('btn-envio-cancelar');
     // ---- Fluxos ----
     const flowsListView = document.getElementById('flows-list-view');
     const flowEditorView = document.getElementById('flow-editor-view');
-    const btnNewFlow = document.getElementById('btn-new-flow');
+    const btnCreateNewFlow = document.getElementById('btn-create-new-flow');
     const btnCancelFlow = document.getElementById('btn-cancel-flow');
     const btnSaveFlow = document.getElementById('btn-save-flow');
     const flowNameInput = document.getElementById('flow-name');
     const flowTriggerInput = document.getElementById('flow-trigger');
     const flowActiveInput = document.getElementById('flow-active');
     const nodesContainer = document.getElementById('nodes-container');
+    const flowsListContainer = document.getElementById('flows-list-container');
     let editingFlowId = null;
 
     function showFlowsList() {
@@ -2188,7 +2225,9 @@ const btnEnvioCancelarEl = document.getElementById('btn-envio-cancelar');
         }
     }
 
-    if (btnNewFlow) btnNewFlow.addEventListener('click', () => showFlowEditor());
+    if (btnCreateNewFlow) btnCreateNewFlow.addEventListener('click', () => {
+        window.location.href = '/flows/builder.html';
+    });
     if (btnCancelFlow) btnCancelFlow.addEventListener('click', showFlowsList);
     if (btnSaveFlow) btnSaveFlow.addEventListener('click', saveCurrentFlow);
 


### PR DESCRIPTION
## Summary
- add conversation flows view to index.html
- fetch flows via new `loadAndRenderFlows()`
- wire up menu to open the new view
- link "Criar Novo Fluxo" button to builder page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6883dafccb608321a45d5562d083f812