### PR TITLE
Fix builder page markup

### DIFF
--- a/public/flows/builder.html
+++ b/public/flows/builder.html
@@ -1,1 +1,36 @@
-<h1>Builder de Fluxo</h1>
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <title>Builder de Fluxo</title>
+    <link rel="stylesheet" href="../style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="page-container">
+        <header class="page-header">
+            <div>
+                <input type="text" id="flow-name" placeholder="Nome do Fluxo" />
+            </div>
+            <div>
+                <button id="btn-save-flow" class="btn-primary">Salvar Fluxo</button>
+            </div>
+        </header>
+
+        <div class="settings-card">
+            <div class="settings-card-body">
+                <label for="flow-trigger">Palavra-chave Gatilho</label>
+                <input type="text" id="flow-trigger" placeholder="Ex: suporte" />
+            </div>
+        </div>
+
+        <div id="nodes-container" class="steps-container" style="margin-top:20px;"></div>
+        <div class="add-step-buttons">
+            <span></span>
+            <button type="button" id="btn-add-node" class="btn-secondary">+ Adicionar Passo</button>
+        </div>
+    </div>
+
+    <script src="builder.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add missing HTML structure to `public/flows/builder.html` so the flow builder works

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6883eadebe108321b1f040d90a92c37c