### PR TITLE
Implement visual flow builder with React Flow

### DIFF
--- a/public/flows/visual.html
+++ b/public/flows/visual.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <title>Construtor Visual de Fluxo</title>
+    <link rel="stylesheet" href="../style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reactflow@11.11.4/dist/style.css">
+    <style>
+        #root { width: 100%; height: 80vh; }
+        .toolbar { margin: 10px 0; display: flex; gap: 8px; }
+    </style>
+</head>
+<body>
+<div class="page-container">
+    <header class="page-header">
+        <div>
+            <input type="text" id="flow-name" placeholder="Nome do Fluxo" />
+        </div>
+        <div>
+            <button id="btn-save-flow" class="btn-primary">Salvar Fluxo</button>
+        </div>
+    </header>
+    <div class="settings-card">
+        <div class="settings-card-body">
+            <label for="flow-trigger">Palavra-chave Gatilho</label>
+            <input type="text" id="flow-trigger" placeholder="Ex: suporte" />
+        </div>
+    </div>
+    <div class="toolbar">
+        <button id="add-message" class="btn-secondary">+ Mensagem</button>
+        <button id="add-question" class="btn-secondary">+ Pergunta</button>
+    </div>
+    <div id="root"></div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.development.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.development.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/reactflow@11.11.4/dist/umd/index.js"></script>
+<script type="module" src="visual.js"></script>
+</body>
+</html>

--- a/public/flows/visual.js
+++ b/public/flows/visual.js
@@ -1,0 +1,131 @@
+const { useState, useCallback, useEffect, Fragment } = React;
+const { createRoot } = ReactDOM;
+const { ReactFlowProvider, ReactFlow, addEdge, applyNodeChanges, applyEdgeChanges, Background, Controls, MiniMap, Handle, Position } = window.ReactFlow;
+
+function StartNode({ data }) {
+  return (
+    React.createElement('div', { className: 'rf-node' },
+      React.createElement('strong', null, 'Início'),
+      React.createElement('div', null, data.label),
+      React.createElement(Handle, { type: 'source', position: Position.Right })
+    )
+  );
+}
+
+function MessageNode({ data }) {
+  return (
+    React.createElement('div', { className: 'rf-node' },
+      React.createElement('div', null, data.label),
+      React.createElement(Handle, { type: 'target', position: Position.Left }),
+      React.createElement(Handle, { type: 'source', position: Position.Right })
+    )
+  );
+}
+
+function QuestionNode({ id, data }) {
+  return (
+    React.createElement('div', { className: 'rf-node' },
+      React.createElement('div', null, data.label),
+      data.options && data.options.map((opt, idx) => (
+        React.createElement('div', { key: idx },
+          React.createElement('small', null, opt.text || 'Opção'),
+          React.createElement(Handle, { type: 'source', position: Position.Right, id: String(idx) })
+        )
+      )),
+      React.createElement(Handle, { type: 'target', position: Position.Left })
+    )
+  );
+}
+
+const nodeTypes = { start: StartNode, message: MessageNode, question: QuestionNode };
+
+function FlowEditor({ flowId }) {
+  const [nodes, setNodes] = useState([]);
+  const [edges, setEdges] = useState([]);
+
+  const onNodesChange = useCallback(changes => setNodes(nds => applyNodeChanges(changes, nds)), []);
+  const onEdgesChange = useCallback(changes => setEdges(eds => applyEdgeChanges(changes, eds)), []);
+  const onConnect = useCallback(params => setEdges(eds => addEdge(params, eds)), []);
+
+  const addMessage = () => setNodes(nds => [...nds, { id: `n${nds.length+1}`, type: 'message', position: { x: 250, y: nds.length*80 }, data: { label: 'Mensagem' } }]);
+  const addQuestion = () => setNodes(nds => [...nds, { id: `n${nds.length+1}`, type: 'question', position: { x: 250, y: nds.length*80 }, data: { label: 'Pergunta', options: [{ text: 'Sim' }, { text: 'Não' }] } }]);
+
+  useEffect(() => {
+    if (!flowId) return;
+    fetch(`/api/flows/${flowId}`).then(r => r.json()).then(f => {
+      const loadedNodes = [];
+      const loadedEdges = [];
+      (f.FlowNodes || []).forEach((n, idx) => {
+        loadedNodes.push({
+          id: String(n.id),
+          type: n.node_type === 'start' ? 'start' : n.node_type,
+          position: { x: 250, y: idx * 80 },
+          data: { label: n.message_text || '', options: n.NodeOptions }
+        });
+        if (Array.isArray(n.NodeOptions)) {
+          n.NodeOptions.forEach((opt, oidx) => {
+            if (opt.next_node_id) {
+              loadedEdges.push({ id: `e${n.id}-${opt.next_node_id}-${oidx}`, source: String(n.id), sourceHandle: String(oidx), target: String(opt.next_node_id), label: opt.option_text });
+            }
+          });
+        }
+      });
+      setNodes(loadedNodes);
+      setEdges(loadedEdges);
+      document.getElementById('flow-name').value = f.name || '';
+      document.getElementById('flow-trigger').value = f.trigger_keyword || '';
+    });
+  }, [flowId]);
+
+  const collectData = () => {
+    return {
+      name: document.getElementById('flow-name').value.trim(),
+      trigger_keyword: document.getElementById('flow-trigger').value.trim(),
+      nodes: nodes.map((n, idx) => ({
+        node_type: n.type,
+        message_text: n.data.label,
+        is_start_node: idx === 0,
+        options: edges.filter(e => e.source === n.id).map(e => ({ option_text: e.label || '', next_node_id: parseInt(e.target, 10) }))
+      }))
+    };
+  };
+
+  const save = () => {
+    const data = collectData();
+    if (!data.name || !data.trigger_keyword) {
+      alert('Preencha nome e gatilho');
+      return;
+    }
+    const url = flowId ? `/api/flows/${flowId}` : '/api/flows';
+    const method = flowId ? 'PUT' : 'POST';
+    fetch(url, { method, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) })
+      .then(resp => { if (resp.ok) window.location.href = 'flows.html'; else alert('Falha ao salvar fluxo'); });
+  };
+
+  useEffect(() => {
+    document.getElementById('btn-save-flow').addEventListener('click', save);
+    document.getElementById('add-message').addEventListener('click', addMessage);
+    document.getElementById('add-question').addEventListener('click', addQuestion);
+  }, []);
+
+  return (
+    React.createElement(ReactFlowProvider, null,
+      React.createElement(ReactFlow, {
+        nodes, edges, nodeTypes,
+        onNodesChange, onEdgesChange, onConnect,
+        fitView: true,
+        style: { width: '100%', height: '80vh' }
+      },
+        React.createElement(MiniMap, null),
+        React.createElement(Controls, null),
+        React.createElement(Background, null)
+      )
+    )
+  );
+}
+
+const params = new URLSearchParams(window.location.search);
+const flowId = params.get('id');
+
+createRoot(document.getElementById('root')).render(React.createElement(FlowEditor, { flowId }));
+


### PR DESCRIPTION
## Summary
- add a new page to build flows visually
- implement React Flow builder logic using CDN modules

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6883edefc10c83218ea47ce63d7a926f