### PR TITLE
Switch to React Flow visual builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,14 @@ meu-bot-rastreamento/
     └── middleware/         # Autenticação e checagem de planos
 ```
 
+## 🖌 Editor Visual de Fluxos
+
+O painel inclui um construtor de fluxos totalmente visual utilizando [React Flow](https://reactflow.dev).
+Ao clicar em **Criar Novo Fluxo** ou editar um existente, o navegador abre `flows/visual.html`.
+Nessa página é possível arrastar os blocos e conectar as saídas para montar o
+diagrama da conversa. Ao salvar, a estrutura é enviada para as rotas da API
+responsáveis por persistir os nós e as opções.
+
 ---
 
 ## 🔒 Requisitos

--- a/public/script.js
+++ b/public/script.js
@@ -2226,7 +2226,7 @@ const btnEnvioCancelarEl = document.getElementById('btn-envio-cancelar');
     }
 
     if (btnCreateNewFlow) btnCreateNewFlow.addEventListener('click', () => {
-        window.location.href = '/flows/builder.html';
+        window.location.href = '/flows/visual.html';
     });
     if (btnCancelFlow) btnCancelFlow.addEventListener('click', showFlowsList);
     if (btnSaveFlow) btnSaveFlow.addEventListener('click', saveCurrentFlow);
@@ -2240,8 +2240,7 @@ const btnEnvioCancelarEl = document.getElementById('btn-envio-cancelar');
         if (!card) return;
         const id = card.dataset.flowId;
         if (editBtn) {
-            const flow = flowsCache.find(f => String(f.id) === String(id));
-            if (flow) showFlowEditor(flow);
+            window.location.href = `/flows/visual.html?id=${id}`;
         }
         if (deleteBtn) {
             showConfirmationModal('Deseja realmente excluir este fluxo?', async () => {


### PR DESCRIPTION
## Summary
- update main script to open the new React Flow page when creating or editing flows
- document the visual flow editor in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6883f1c2bd008321bc5d6c7268add363