### PR TITLE
Implement conversation flow engine

### DIFF
--- a/src/database/database.js
+++ b/src/database/database.js
@@ -199,8 +199,8 @@ function defineModels(sequelize) {
 
   Flow.hasMany(FlowNode, { foreignKey: 'flow_id' });
   FlowNode.belongsTo(Flow, { foreignKey: 'flow_id' });
-  FlowNode.hasMany(NodeOption, { foreignKey: 'node_id' });
-  NodeOption.belongsTo(FlowNode, { foreignKey: 'node_id' });
+  FlowNode.hasMany(NodeOption, { foreignKey: 'source_node_id' });
+  NodeOption.belongsTo(FlowNode, { foreignKey: 'source_node_id' });
 
   return { User, Plan, Subscription, Pedido, Historico, Log, Automacao, AutomacaoPasso, Integration, IntegrationSetting, UserSetting, Flow, FlowNode, NodeOption, UserFlowState };
 }

--- a/src/flows/flow.model.js
+++ b/src/flows/flow.model.js
@@ -1,10 +1,10 @@
 module.exports = (sequelize, DataTypes) => {
   const Flow = sequelize.define('Flow', {
     id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
-    cliente_id: { type: DataTypes.INTEGER, allowNull: false },
-    nome: { type: DataTypes.STRING, allowNull: false },
-    gatilho: { type: DataTypes.STRING, allowNull: false },
-    ativo: { type: DataTypes.INTEGER, defaultValue: 1 }
+    user_id: { type: DataTypes.INTEGER, allowNull: false },
+    name: { type: DataTypes.STRING, allowNull: false },
+    trigger_keyword: { type: DataTypes.STRING, allowNull: false },
+    is_active: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true }
   }, { tableName: 'flows', timestamps: true });
   return Flow;
 };

--- a/src/flows/flowNode.model.js
+++ b/src/flows/flowNode.model.js
@@ -2,9 +2,9 @@ module.exports = (sequelize, DataTypes) => {
   const FlowNode = sequelize.define('FlowNode', {
     id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
     flow_id: { type: DataTypes.INTEGER, allowNull: false },
-    tipo: { type: DataTypes.STRING, allowNull: false },
-    conteudo: DataTypes.TEXT,
-    next_node_id: DataTypes.INTEGER
+    node_type: { type: DataTypes.STRING, allowNull: false },
+    message_text: DataTypes.TEXT,
+    is_start_node: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false }
   }, { tableName: 'flow_nodes', timestamps: true });
   return FlowNode;
 };

--- a/src/flows/nodeOption.model.js
+++ b/src/flows/nodeOption.model.js
@@ -1,8 +1,8 @@
 module.exports = (sequelize, DataTypes) => {
   const NodeOption = sequelize.define('NodeOption', {
     id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
-    node_id: { type: DataTypes.INTEGER, allowNull: false },
-    label: { type: DataTypes.STRING, allowNull: false },
+    source_node_id: { type: DataTypes.INTEGER, allowNull: false },
+    option_text: { type: DataTypes.STRING, allowNull: false },
     next_node_id: DataTypes.INTEGER
   }, { tableName: 'node_options', timestamps: true });
   return NodeOption;

--- a/src/flows/userFlowState.model.js
+++ b/src/flows/userFlowState.model.js
@@ -1,10 +1,9 @@
 module.exports = (sequelize, DataTypes) => {
   const UserFlowState = sequelize.define('UserFlowState', {
     id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
-    cliente_id: { type: DataTypes.INTEGER, allowNull: false },
-    telefone: { type: DataTypes.STRING, allowNull: false },
-    flow_id: { type: DataTypes.INTEGER, allowNull: false },
-    node_id: DataTypes.INTEGER
-  }, { tableName: 'user_flow_state', timestamps: true });
+    pedido_id: { type: DataTypes.INTEGER, allowNull: false },
+    current_flow_id: { type: DataTypes.INTEGER, allowNull: false },
+    current_node_id: DataTypes.INTEGER
+  }, { tableName: 'user_flow_states', timestamps: true });
   return UserFlowState;
 };

--- a/src/services/flows/flowEngineService.js
+++ b/src/services/flows/flowEngineService.js
@@ -1,0 +1,59 @@
+const { getModels } = require('../../database/database');
+const whatsappService = require('../whatsappService');
+
+async function sendNode(client, phone, node) {
+  if (!node) return;
+  const { NodeOption } = getModels();
+  let message = node.message_text || '';
+  if (node.node_type === 'question') {
+    const options = await NodeOption.findAll({ where: { source_node_id: node.id } });
+    if (options.length) {
+      const optsText = options.map(o => `- ${o.option_text}`).join('\n');
+      message = message ? `${message}\n${optsText}` : optsText;
+    }
+  }
+  await whatsappService.enviarMensagem(client, phone, message);
+}
+
+async function processMessage(userId, pedido, text, client) {
+  const { Flow, FlowNode, NodeOption, UserFlowState } = getModels();
+  let state = await UserFlowState.findOne({ where: { pedido_id: pedido.id } });
+
+  if (state) {
+    const current = await FlowNode.findByPk(state.current_node_id);
+    if (!current) { await state.destroy(); return false; }
+
+    if (current.node_type === 'question') {
+      const option = await NodeOption.findOne({ where: { source_node_id: current.id, option_text: text } });
+      if (!option) return false;
+      const nextId = option.next_node_id;
+      if (nextId) {
+        const next = await FlowNode.findByPk(nextId);
+        await sendNode(client, pedido.telefone, next);
+        await state.update({ current_node_id: nextId });
+      } else {
+        await state.destroy();
+      }
+    } else {
+      const opt = await NodeOption.findOne({ where: { source_node_id: current.id } });
+      if (opt && opt.next_node_id) {
+        const next = await FlowNode.findByPk(opt.next_node_id);
+        await sendNode(client, pedido.telefone, next);
+        await state.update({ current_node_id: opt.next_node_id });
+      } else {
+        await state.destroy();
+      }
+    }
+    return true;
+  }
+
+  const flow = await Flow.findOne({ where: { user_id: userId, trigger_keyword: text, is_active: true } });
+  if (!flow) return false;
+  const first = await FlowNode.findOne({ where: { flow_id: flow.id, is_start_node: true } });
+  if (!first) return false;
+  await sendNode(client, pedido.telefone, first);
+  await UserFlowState.create({ pedido_id: pedido.id, current_flow_id: flow.id, current_node_id: first.id });
+  return true;
+}
+
+module.exports = { processMessage };


### PR DESCRIPTION
## Summary
- add conversation flow execution service
- wire flow engine into message handler before saving history
- migrate flow models to english field names
- update database relationships for new flow schema

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688505ce2bb883218e3d03ff49fb15bc