### PR TITLE
Add build-frontend script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "node server.js",
     "create-admin": "node criar-admin.js",
     "clean-users": "node limpar-usuarios.js",
-    "migrate": "sequelize-cli db:migrate"
+    "migrate": "sequelize-cli db:migrate",
+    "build-frontend": "npm --prefix frontend run build"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add a `build-frontend` npm script to make it easier to build React assets

## Testing
- `npm run build-frontend` *(fails: could not read frontend/package.json)*
- `npm test` *(fails: missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_688511b47f3083219fcff7108ae0f862