### PR TITLE
Add initial React Flow nodes

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -40,3 +40,45 @@
 .read-the-docs {
   color: #888;
 }
+
+.node-card {
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 8px;
+  width: 200px;
+}
+
+.node-header {
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.node-input,
+.node-textarea {
+  width: 100%;
+  box-sizing: border-box;
+  margin-bottom: 8px;
+}
+
+.options-section {
+  text-align: left;
+}
+
+.option-item {
+  display: flex;
+  align-items: center;
+  margin-bottom: 4px;
+}
+
+.option-item .node-input {
+  flex: 1;
+  margin-right: 4px;
+}
+
+.btn-secondary {
+  background: #eee;
+  border: 1px solid #ccc;
+  padding: 4px 8px;
+  cursor: pointer;
+}

--- a/frontend/src/Canvas.jsx
+++ b/frontend/src/Canvas.jsx
@@ -1,15 +1,29 @@
 import React from 'react';
 import ReactFlow, { Background, Controls, ReactFlowProvider } from 'reactflow';
 import 'reactflow/dist/style.css';
+import { StartNode, MessageNode, QuestionNode } from './nodes';
 
 function Canvas() {
-  const nodes = [];
+  const nodeTypes = {
+    start: StartNode,
+    message: MessageNode,
+    question: QuestionNode,
+  };
+
+  const nodes = [
+    {
+      id: 'start',
+      type: 'start',
+      position: { x: 0, y: 0 },
+      data: { keyword: '' },
+    },
+  ];
   const edges = [];
 
   return (
     <ReactFlowProvider>
       <div style={{ width: '100%', height: '80vh' }}>
-        <ReactFlow nodes={nodes} edges={edges} fitView>
+        <ReactFlow nodeTypes={nodeTypes} nodes={nodes} edges={edges} fitView>
           <Background />
           <Controls />
         </ReactFlow>

--- a/frontend/src/nodes/MessageNode.jsx
+++ b/frontend/src/nodes/MessageNode.jsx
@@ -1,0 +1,31 @@
+import { Handle, Position } from 'reactflow';
+import { useState } from 'react';
+import '../App.css';
+
+function MessageNode({ data }) {
+  const [message, setMessage] = useState(data.message || '');
+
+  const handleChange = (e) => {
+    setMessage(e.target.value);
+    if (data.onChange) {
+      data.onChange({ ...data, message: e.target.value });
+    }
+  };
+
+  return (
+    <div className="node-card">
+      <div className="node-header">Enviar Mensagem</div>
+      <textarea
+        className="node-textarea"
+        rows="3"
+        placeholder="Texto da mensagem"
+        value={message}
+        onChange={handleChange}
+      />
+      <Handle type="target" position={Position.Top} />
+      <Handle type="source" position={Position.Bottom} />
+    </div>
+  );
+}
+
+export default MessageNode;

--- a/frontend/src/nodes/QuestionNode.jsx
+++ b/frontend/src/nodes/QuestionNode.jsx
@@ -1,0 +1,66 @@
+import { Handle, Position } from 'reactflow';
+import { useState } from 'react';
+import '../App.css';
+
+function QuestionNode({ data }) {
+  const [question, setQuestion] = useState(data.question || '');
+  const [options, setOptions] = useState(data.options || []);
+
+  const handleQuestionChange = (e) => {
+    setQuestion(e.target.value);
+    triggerChange({ question: e.target.value, options });
+  };
+
+  const triggerChange = (newData) => {
+    if (data.onChange) {
+      data.onChange({ ...data, ...newData });
+    }
+  };
+
+  const handleOptionChange = (index, value) => {
+    const newOpts = [...options];
+    newOpts[index] = value;
+    setOptions(newOpts);
+    triggerChange({ question, options: newOpts });
+  };
+
+  const addOption = () => {
+    const newOpts = [...options, ''];
+    setOptions(newOpts);
+    triggerChange({ question, options: newOpts });
+  };
+
+  return (
+    <div className="node-card">
+      <div className="node-header">Pergunta com Opções</div>
+      <textarea
+        className="node-textarea"
+        rows="3"
+        placeholder="Digite a pergunta"
+        value={question}
+        onChange={handleQuestionChange}
+      />
+      <div className="options-section">
+        <h6>Opções de Resposta</h6>
+        {options.map((opt, idx) => (
+          <div key={idx} className="option-item">
+            <input
+              type="text"
+              className="node-input"
+              placeholder={`Opção ${idx + 1}`}
+              value={opt}
+              onChange={(e) => handleOptionChange(idx, e.target.value)}
+            />
+            <Handle type="source" position={Position.Right} id={`opt-${idx}`} />
+          </div>
+        ))}
+        <button type="button" className="btn-secondary" onClick={addOption}>
+          + Adicionar Opção
+        </button>
+      </div>
+      <Handle type="target" position={Position.Top} />
+    </div>
+  );
+}
+
+export default QuestionNode;

--- a/frontend/src/nodes/StartNode.jsx
+++ b/frontend/src/nodes/StartNode.jsx
@@ -1,0 +1,30 @@
+import { Handle, Position } from 'reactflow';
+import { useState } from 'react';
+import '../App.css';
+
+function StartNode({ data }) {
+  const [keyword, setKeyword] = useState(data.keyword || '');
+
+  const handleChange = (e) => {
+    setKeyword(e.target.value);
+    if (data.onChange) {
+      data.onChange({ ...data, keyword: e.target.value });
+    }
+  };
+
+  return (
+    <div className="node-card">
+      <div className="node-header">Início do Fluxo</div>
+      <input
+        type="text"
+        className="node-input"
+        placeholder="Palavra-chave"
+        value={keyword}
+        onChange={handleChange}
+      />
+      <Handle type="source" position={Position.Bottom} />
+    </div>
+  );
+}
+
+export default StartNode;

--- a/frontend/src/nodes/index.js
+++ b/frontend/src/nodes/index.js
@@ -1,0 +1,3 @@
+export { default as StartNode } from './StartNode.jsx';
+export { default as MessageNode } from './MessageNode.jsx';
+export { default as QuestionNode } from './QuestionNode.jsx';


### PR DESCRIPTION
## Summary
- create custom React Flow nodes (StartNode, MessageNode, QuestionNode)
- register node types in the Canvas
- add minimal styles for node cards

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688516e817d483218bdb371e2aa688c2