### PR TITLE
Add context menu to create nodes

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -89,17 +89,30 @@
   height: 80vh;
 }
 
-.toolbar {
-  display: flex;
-  flex-direction: column;
-  margin-right: 8px;
-}
-
-.toolbar button {
-  margin-bottom: 4px;
-}
 
 .flow-area {
   flex: 1;
   height: 100%;
+}
+
+.add-node-btn {
+  margin-top: 4px;
+  padding: 2px 6px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.context-menu {
+  position: absolute;
+  background: #fff;
+  border: 1px solid #ccc;
+  padding: 4px;
+  z-index: 10;
+}
+
+.context-menu button {
+  display: block;
+  width: 100%;
+  margin: 2px 0;
+  cursor: pointer;
 }

--- a/frontend/src/nodes/MessageNode.jsx
+++ b/frontend/src/nodes/MessageNode.jsx
@@ -24,6 +24,15 @@ function MessageNode({ data }) {
       />
       <Handle type="target" position={Position.Top} />
       <Handle type="source" position={Position.Bottom} />
+      {data.onAdd && (
+        <button
+          type="button"
+          className="add-node-btn"
+          onClick={(e) => data.onAdd(e)}
+        >
+          +
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/nodes/QuestionNode.jsx
+++ b/frontend/src/nodes/QuestionNode.jsx
@@ -52,6 +52,15 @@ function QuestionNode({ data }) {
               onChange={(e) => handleOptionChange(idx, e.target.value)}
             />
             <Handle type="source" position={Position.Right} id={`opt-${idx}`} />
+            {data.onAdd && (
+              <button
+                type="button"
+                className="add-node-btn"
+                onClick={(e) => data.onAdd(e, `opt-${idx}`)}
+              >
+                +
+              </button>
+            )}
           </div>
         ))}
         <button type="button" className="btn-secondary" onClick={addOption}>

--- a/frontend/src/nodes/StartNode.jsx
+++ b/frontend/src/nodes/StartNode.jsx
@@ -23,6 +23,15 @@ function StartNode({ data }) {
         onChange={handleChange}
       />
       <Handle type="source" position={Position.Bottom} />
+      {data.onAdd && (
+        <button
+          type="button"
+          className="add-node-btn"
+          onClick={(e) => data.onAdd(e)}
+        >
+          +
+        </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- switch to context menu for adding nodes on the canvas
- allow clicking `+` buttons on nodes to open the menu
- connect newly created nodes automatically
- style new context menu and add-node buttons

## Testing
- `npm --prefix frontend run lint`

------
https://chatgpt.com/codex/tasks/task_e_68852580b4648321a5080cab3e5fc313